### PR TITLE
Fix reference to old default branch on actionshub/chef-install

### DIFF
--- a/.github/workflows/chef-cookbook-linting.yml
+++ b/.github/workflows/chef-cookbook-linting.yml
@@ -1,3 +1,4 @@
+---
 name: chef-cookbook-linting
 
 on: workflow_call

--- a/.github/workflows/chef-cookbook-supermarket-upload.yml
+++ b/.github/workflows/chef-cookbook-supermarket-upload.yml
@@ -1,3 +1,4 @@
+---
 name: chef-cookbook-supermarket-upload
 
 on:

--- a/.github/workflows/chef-cookbook-test-kitchen.yml
+++ b/.github/workflows/chef-cookbook-test-kitchen.yml
@@ -1,3 +1,4 @@
+---
 name: chef-cookbook-test-kitchen
 
 on:
@@ -44,7 +45,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Install Chef
-        uses: actionshub/chef-install@master
+        uses: actionshub/chef-install@main
       - name: Run test-kitchen
         run: |
           kitchen test ${SUITE}-${OS} -d always

--- a/.github/workflows/rubygem-linting.yml
+++ b/.github/workflows/rubygem-linting.yml
@@ -1,3 +1,4 @@
+---
 name: rubygem-linting
 
 on: workflow_call


### PR DESCRIPTION
## Description

One of the `actionshub/chef-install` references still pointed to the old `master` branch, resulting in Dokken failures.

## Issues Resolved

Dokken jobs failed with `Unable to resolve action`
